### PR TITLE
Differentiate message urls with color and show a hover state on the children

### DIFF
--- a/Custom-Stable.css
+++ b/Custom-Stable.css
@@ -673,12 +673,31 @@
 	color: #49a6d2 !important;
 }
 
-#-webkit-web-inspector .console-warning-level .console-message-text {
+#-webkit-web-inspector #console-messages .console-log-level .console-message-text,
+#-webkit-web-inspector #console-messages .console-log-level .console-message-url {
+	color: #49a6d2 !important;
+}
+
+#-webkit-web-inspector #console-messages .console-log-level .children div:hover * {
+	color: #337492 !important;
+}
+
+#-webkit-web-inspector #console-messages .console-warning-level .console-message-text,
+#-webkit-web-inspector #console-messages .console-warning-level .console-message-url {
 	color: #db0 !important;
 }
 
-#-webkit-web-inspector .console-error-level .console-message-text {
+#-webkit-web-inspector #console-messages .console-warning-level .children div:hover * {
+	color: #9D8500 !important;
+}
+
+#-webkit-web-inspector #console-messages .console-error-level .console-message-text, 
+#-webkit-web-inspector #console-messages .console-error-level .console-message-url {
 	color: #f66 !important;
+}
+
+#-webkit-web-inspector #console-messages .console-error-level .children div:hover * {
+	color: #bf4c4c !important;
 }
 
 #-webkit-web-inspector #console-messages a {
@@ -1815,5 +1834,4 @@
 #-webkit-web-inspector .data-grid tr.selected td *{
 	color: #ddd !important;
 }
-
 


### PR DESCRIPTION
Hi Maurice!
    I use the console a lot for debug and I've been having trouble differentiating between the js links. Especially when hovering (this a problem on default chorme as well, not just this css). I've customized the console message children slightly to show more of a differentiation. I've attached a screenshot showing the change and it shows one of the message children with hover as well.

I haven't changed the other css as I don't have Canary to be able to test it...

![screen shot 2013-07-17 at 10 46 39 am](https://f.cloud.github.com/assets/730594/812916/27a0d5b4-eef8-11e2-98ba-b645d7cc3329.png)
