### PR TITLE
Resources -> FileSystem - Dark text in treeview

### DIFF
--- a/canary-theme-extension/styles.css
+++ b/canary-theme-extension/styles.css
@@ -1409,6 +1409,10 @@ body.platform-mac-mountain-lion .toolbar-background {
 .database-user-query .error {
   color: #f66 !important;
 }
+/*-- FileSystem --*/
+.filesystem-directory-tree li {
+  color: #999;
+}
 /*************************************
  * Help/Settings Overlay
  *************************************/


### PR DESCRIPTION
Before:
![before](https://f.cloud.github.com/assets/2838324/1797335/13c58c00-6acd-11e3-8f40-58ed9e2ba7be.jpg)

After:
![after](https://f.cloud.github.com/assets/2838324/1797334/1395f6f2-6acd-11e3-91ec-8423835147b2.jpg)

Removed duplicated code - see: 
https://github.com/mauricecruz/chrome-devtools-zerodarkmatrix-theme/blob/master/canary-theme-extension/styles.css#L2063-L2097
