### PR TITLE
style the selected text/matched/unmatched brackets

### DIFF
--- a/theme-extension/stable.css
+++ b/theme-extension/stable.css
@@ -236,17 +236,18 @@
 }
 .CodeMirror-selected,
 span.CodeMirror-selectedtext {
-  background: #3c3c3c !important;
+  background: #F0D3AC !important;
+  color: #ffffff !important;
 }
 .CodeMirror-matchingbracket {
-  color: #15ca1a !important;
-  text-shadow: 0 0 3px #15ca1a !important;
+  color: #000 !important;
   border-bottom: none !important;
+  background-color: #A6E22E !important;
 }
 .CodeMirror-nonmatchingbracket {
-  color: #db0404 !important;
-  text-shadow: 0 0 3px #db0404 !important;
+  background-color: #DB0404 !important;
   border-bottom: none !important;
+  color: #FFF !important;
 }
 .cm-search-highlight-start:before {
   border-color: #89f5a2 !important;


### PR DESCRIPTION
The current style are not easily noticeable. The latest one colors was
picked from many dark theme like Sublime Monokai

Matching Brackets
![matching-brackets](https://cloud.githubusercontent.com/assets/281531/4500582/d85eebe4-4a95-11e4-9180-b33f55b5cacb.png)
![new-matching-brackets](https://cloud.githubusercontent.com/assets/281531/4500584/d85f3f72-4a95-11e4-8799-5f09709465db.png)

Unmatched Brackets
![unmatched-brackets](https://cloud.githubusercontent.com/assets/281531/4500583/d85f316c-4a95-11e4-86dc-f0003d03970e.png)
![new-unmatched-brackets](https://cloud.githubusercontent.com/assets/281531/4500585/d861d2d2-4a95-11e4-95b9-822ea144d57b.png)

Selected Texts
![select-text](https://cloud.githubusercontent.com/assets/281531/4500581/d85e98d8-4a95-11e4-9520-c78a226252a0.png)
![new-select-text](https://cloud.githubusercontent.com/assets/281531/4500580/d85e8e42-4a95-11e4-89f4-6581eb5f0554.png)
